### PR TITLE
Сделал дз kubernertes-controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # yd47_platform
 yd47 Platform repository
+
+## Worklog
+
+Урок 2. [kubernetes-intro](#kubernetes-intro)
+
+Урок 3. [kubernetes-controllers](#kubernetes-controllers)
+
+## kubernetes-intro
+2023-07-09 Сделал задания из kubernetes-intro: 
+```
+Изучил:
+  - базовую архитектуру (control plane, worker node);
+  - поднял кластер в minikube;
+  - познакомился как проверять состояние кластера, состояние компонент, список pod;
+  - создавать pod из манифеста;
+  - смотреть логи и события по pod'am (describe, logs)
+  - запускать предполетные :) подготовки с директивой initContainers
+```
+## kubernetes-controllers
+2023-07-15 Сделал занятия из kubernetes-controllers:
+```
+Изучил:
+  - Работу с selector: матчинг ресурсов по key/value;
+  - Probes: проверки, что приложение живое, а не поймало deadlock;
+  - Зачем нужен Deployment и почему не обойтись ReplicaSet;
+  - Daemonset - pod'ы, которые всегда будут добавляться на ноды кластера;
+  - Обновление приложений с помощью Deployment, проверка успешности, откаты;
+  - Стратегии обновления приложений
+```

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: hardkov/hipster-frontend:v0.0.2
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"        

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: hardkov/hipster-frontend:v0.0.2
+        ports:
+        - containerPort: 8080
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"        

--- a/kubernetes-controllers/nodeexporter-daemonset.yaml
+++ b/kubernetes-controllers/nodeexporter-daemonset.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  labels:
+    k8s-app: monitoring
+spec:
+  selector:
+    matchLabels:
+      name: node-exporter
+  template:
+    metadata:
+      labels:
+        name: node-exporter
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: node-exporter
+        image: prom/node-exporter:v1.6.0
+        ports:
+        - containerPort: 9100
+      nodeSelector:
+        kubernetes.io/os: linux
+        

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -10,7 +10,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 3
-      maxUnavailable: 3
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: paymentservice

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: hardkov/paymentservice:v0.0.2
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -9,7 +9,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: hardkov/paymentservice:v0.0.2
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: hardkov/paymentservice:v0.0.2
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: hardkov/paymentservice:v0.0.1
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"        


### PR DESCRIPTION
# Выполнено ДЗ №3 kubernetes-controllers

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Теоретическое задание:
Вопрос: Почему обновление ReplicaSet не повлекло обновление запущенных pod?
Ответ: За обновление конфигурации pod следит Deployment. ReplicaSet обеспечивает желаемое количество работающих реплик подов в кластере, но обновлять конфигурацию не умеет.

 - ReplicaSet: `frontend-replicaset.yaml` здесь не хватало секции `.spec.selector` - блок добавил:
 ```
   selector:
    matchLabels:
      app: frontend
 ```
так же сделал 3 реплики сервиса и явно объявил порт контейнера в yaml файле

 - ReplicaSet: `paymentservice-replicaset.yaml` приложение `paymentService`  с тремя репликами на версии образа `v0.0.1`

 - Deployment: `paymentservice-deployment.yaml` для приложения `paymentService`. Для его работы потребовалось добавить недостающие переменные:
```
- name: PORT
  value: "50051"
- name: DISABLE_PROFILER
  value: "1"
```
- Deployment, задание со *: `paymentservice-deployment-bg.yaml` и `paymentservice-deployment-reverse.yaml`
Стратегии обновления задал с помощью переменных:
`maxSurge` - сколько новых pod может быть создано в момент времени;
`maxUnavailable` - сколько pod может быть недоступно в момент времени

- Deployment: `frontend-deployment.yaml` - в манифест добавлен `readinessProbe` для проверки того, что приложение отвечает на http запросы

- DaemonSet, задание со *: `nodeexporter-daemonset.yaml` - можно собрать метрики с node-exporter
- DaemonSet, задание c **: `nodeexporter-daemonset.yaml` - подробнее опишу в #Как проверить работоспособность

## Как запустить проект:
 - kubectl apply -f <имя-манифеста>

## Как проверить работоспособность:
 - при обновлении приложений через Deployment, можно проверить, что обновление прошло успешно с помощью команды: `kubectl rollout status deployment/<name>`
- DaemonSet, задание со *: `nodeexporter-daemonset.yaml` 
Пробросить порт: `kubectl port-forward node-exporter-hs6rp 9100:9100`
Обратиться к node-exporter curl: `curl localhost:9100/metrics`
- DaemonSet, задание c **: `nodeexporter-daemonset.yaml`. Для добавления pod на master ноды добавил блок:
```
      tolerations:
      - key: node-role.kubernetes.io/control-plane
        operator: Exists
        effect: NoSchedule
      - key: node-role.kubernetes.io/master
        operator: Exists
        effect: NoSchedule
```
Проверить можно командой:
```
kubectl get pod -l name=node-exporter -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
NAME                  STATUS    NODE
node-exporter-5gqxr   Running   kind-worker3
node-exporter-89ts7   Running   kind-worker
node-exporter-bt5c6   Running   kind-control-plane2
node-exporter-qpljn   Running   kind-control-plane3
node-exporter-rpss9   Running   kind-control-plane
node-exporter-z9vdl   Running   kind-worker2
```
## PR checklist:
 - [x] Выставлен label с темой домашнего задания
