### PR TITLE
Сделал дз kubernetes-networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ yd47 Platform repository
 ## Worklog
 
 Урок 2. [kubernetes-intro](#kubernetes-intro)
+Урок 3. [kubernetes-controllers](#kubernetes-controllers)
+Урок 4. [kubernetes-networks](#kubernetes-networks)
 
 ## kubernetes-intro
 2023-07-09 Сделал задания из kubernetes-intro: 
@@ -15,3 +17,28 @@ yd47 Platform repository
   - создавать pod из манифеста;
   - смотреть логи и события по pod'am (describe, logs)
   - запускать предполетные :) подготовки с директивой initContainers
+
+```
+## kubernetes-controllers
+2023-07-15 Сделал задания из kubernetes-controllers:
+```
+Изучил:
+  - Работу с selector: матчинг ресурсов по key/value;
+  - Probes: проверки, что приложение живое, а не поймало deadlock;
+  - Зачем нужен Deployment и почему не обойтись ReplicaSet;
+  - Daemonset - pod'ы, которые всегда будут добавляться на ноды кластера;
+  - Обновление приложений с помощью Deployment, проверка успешности, откаты;
+  - Стратегии обновления приложений
+```
+
+## kubernetes-networks
+2023-07-22 Сделал задания из kubernetes-controllers:
+```
+Изучил:
+  - readinessProbe (готовность принимать запросы) и livenessProbe (что процесс живой);
+  - Создание Service: ClusterIP, Ingress и доступ к приложениям через эти сервисы;
+  - Включение балансировщика IPVS (работает на 4 ур TCP/IP); 
+  - Установку MetalLB;
+  - Установку kubernetes-dashboard;
+  - Канареечный деплой
+```

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ yd47 Platform repository
 
 ## Worklog
 
-Урок 2. [kubernetes-intro](#kubernetes-intro)
-Урок 3. [kubernetes-controllers](#kubernetes-controllers)
-Урок 4. [kubernetes-networks](#kubernetes-networks)
+- Урок 2. [kubernetes-intro](#kubernetes-intro)
+- Урок 3. [kubernetes-controllers](#kubernetes-controllers)
+- Урок 4. [kubernetes-networks](#kubernetes-networks)
 
 ## kubernetes-intro
 2023-07-09 Сделал задания из kubernetes-intro: 

--- a/kubernetes-networks/canary/ingress-header-canary.yaml
+++ b/kubernetes-networks/canary/ingress-header-canary.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress 
+metadata:
+  name: web
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    # Set the request header to foo. 
+    nginx.ingress.kubernetes.io/canary-by-header: "foo"
+    # Only requests whose headers are foo and header values are bar are forwarded to the new-nginx Service. 
+    nginx.ingress.kubernetes.io/canary-by-header-value: "bar"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /canary
+            pathType: Prefix
+            backend:
+              service:
+                name: canary-app
+                port:
+                  number: 80

--- a/kubernetes-networks/canary/ingress-header.yaml
+++ b/kubernetes-networks/canary/ingress-header.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress 
+metadata:
+  name: web
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /canary
+            pathType: Prefix
+            backend:
+              service:
+                name: canary-app
+                port:
+                  number: 80

--- a/kubernetes-networks/canary/ingress-weight-canary.yaml
+++ b/kubernetes-networks/canary/ingress-weight-canary.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress 
+metadata:
+  name: web
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /canary
+            pathType: Prefix
+            backend:
+              service:
+                name: canary-app
+                port:
+                  number: 80

--- a/kubernetes-networks/canary/ingress-weight.yaml
+++ b/kubernetes-networks/canary/ingress-weight.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress 
+metadata:
+  name: web
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /canary
+            pathType: Prefix
+            backend:
+              service:
+                name: canary-app
+                port:
+                  number: 80

--- a/kubernetes-networks/canary/web-pod.yaml
+++ b/kubernetes-networks/canary/web-pod.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1 
+kind: Deployment 
+metadata:
+  name: canary-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: canary-app
+  template:
+    metadata:
+      labels:
+        app: canary-app
+    spec:
+      containers:
+      - name: canary-app
+        image: strm/helloworld-http
+        ports:
+        - containerPort: 80
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: canary-app
+  labels:
+    app: canary-app
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: canary-app

--- a/kubernetes-networks/coredns/dns-svc-lb.yaml
+++ b/kubernetes-networks/coredns/dns-svc-lb.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-svc-tcp-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "dns-svc-lb"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.53
+  ports:
+    - name: dnstcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-svc-udp-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "dns-svc-lb"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.53
+  ports:
+    - name: dnsudp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/kubernetes-networks/dashboard/web-ingress-dash.yaml
+++ b/kubernetes-networks/dashboard/web-ingress-dash.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress 
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard  
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ redirect;
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /dashboard(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: kubernetes-dashboard
+                port:
+                  number: 80

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: first-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.17.255.1-172.17.255.255

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1 
+kind: Service 
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress 
+metadata:
+  name: web
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /web
+            pathType: Prefix
+            backend:
+              service:
+                name: web-svc
+                port:
+                  number: 8000

--- a/kubernetes-networks/web-pod.yaml
+++ b/kubernetes-networks/web-pod.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1 
+kind: Deployment 
+metadata:
+  name: web
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: hardkov/yd47_platform:nginx_0.0.1
+        ports:
+        - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket: { port: 8000 }
+        volumeMounts:
+        - name: workdir
+          mountPath: /app
+      initContainers:
+      - name: install
+        image: busybox:1.28
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: workdir
+          mountPath: /app
+      volumes:
+      - name: workdir
+        emptyDir: {}

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1 
+kind: Service 
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1 
+kind: Service 
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1 
+kind: Service 
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Теоретическое задание:
   Вопрос: Почему следующая конфигурация валидна, но не имеет смысла?
   Ответ: Думаю причина в том, что приложение могло сбойнуть и прекратить корректно обрабатывать запросы, но не упасть с каким-то exception, тогда процесс от запущенного приложения останется. При такой проверке мы будем считать, что приложение работает, а по факту нет. 

    Вопрос: Бывают ли ситуации, когда она все-таки имеет смысл?
    Ответ: не придумал вариантов

 - MetalLB | Проверка конфигурации
   Сервис получил IP из IPAddressPool балансера:
   ```
   web-svc-lb    LoadBalancer   10.102.152.121   172.17.255.1   80:32164/TCP   5s
   ```
- Задание со звездочкой: DNS через MetalLB
  Поднял два сервиса с 172.17.255.53, работают по TCP и UDP:

  ```
  $ k -n kube-system get services
  NAME             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                  AGE
  dns-svc-tcp-lb   LoadBalancer   10.104.229.79   172.17.255.53   53:30952/TCP             13s
  dns-svc-udp-lb   LoadBalancer   10.97.75.54     172.17.255.53   53:31324/UDP             13s
  kube-dns         ClusterIP      10.96.0.10      <none>          53/UDP,53/TCP,9153/TCP   6d22h

  $ nslookup google.com 172.17.255.53
  Server:         172.17.255.53
  Address:        172.17.255.53#53
  
  Non-authoritative answer:
  Name:   google.com
  Address: 216.58.209.206
  Name:   google.com
  Address: 2a00:1450:4026:803::200e
  ```

- Задание со звездочкой: Ingress для Dashboard
  Тут задал специфичный pathType, из-за варнинга: 
  ```
  Warning: path /dashboard(/|$)(.*) cannot be used with pathType Prefix
  pathType: ImplementationSpecific
  ```
  Сам Dashboard доступен из браузера, для этого потребовалось добавить configuration-snippet, иначе не грузились js и css.

- Задание со звездочкой: Canary для Ingress
  Сделал в двух вариантах, через weight и header
  ```
  $ curl -s http://172.17.255.2/canary
  Hello from canary-app-666fdb586b-p64xd
  $ curl -s -H "foo: bar"  http://172.17.255.2/canary
  Hello from canary-app-666fdb586b-tnrs6
  $ curl -s -H "foo: bar"  http://172.17.255.2/canary
  Hello from canary-app-666fdb586b-tnrs6
  $ curl -s -H "foo: bar"  http://172.17.255.2/canary
  Hello from canary-app-666fdb586b-tnrs6
  $ curl -s http://172.17.255.2/canary
  Hello from canary-app-666fdb586b-p64xd
  ```

## Как запустить проект:
- Задание со звездочкой: DNS через MetalLB
  `kubectl apply -f coredns/dns-svc-lb.yaml`

- Задание со звездочкой: Ingress для Dashboard
  `kubectl apply -f dashboard/web-ingress-dash.yaml`

- Задание со звездочкой: Canary для Ingress
  ```
  k create ns prod 
  k create ns canary 
  k apply -f prod-pod.yaml -n prod 
  k apply -f prod-pod.yaml -n canary 
  k apply -f ingress-header.yaml -n prod 
  k apply -f ingress-header-canary.yaml -n canary 
  ```
 Проверка:
  ```
  Попадаем на старый под:
  curl -s http://<ingress-ip>/canary
  
  Попадаем на новый под:
  curl -s -H "foo: bar"  http://<ingress-ip>/canary
  ```

## Как проверить работоспособность:
 - Включить IPVS, установить MetalLB согласно методичке;
 - Настроить MetalLB из манифеста `metallb-config.yaml`; 
 - Установить Nginx Ingress Controller, настроить из манифеста `nginx-lb.yaml`;
 - Добавить маршрут для сети LB, пример: `172.17.255.0/24 via 192.168.49.2 dev br-8624a60e0a41 `;
 - Перейти к настройке Ingress сервисов в разделе "Как запустить проект", текущего Readme.

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
