### PR TITLE
Промежуточный конфиг по hw8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ yd47 Platform repository
 - Урок 6. [kubernetes-security](#kubernetes-security)
 - Урок 7. [kubernetes-templating](#kubernetes-templating)
 - Урок 8. [kubernetes-operators](#kubernetes-operators)
+- Урок 9. [kubernetes-monitoring](#kubernetes-monitoring)
 
 ## kubernetes-intro
 2023-07-09 Сделал задания из kubernetes-intro: 
@@ -64,6 +65,7 @@ yd47 Platform repository
 Изучил:
   - создание Roles и clusterRole - доступ/ограничение к ресурсам в рамках ns/cluster;
   - RBAC: связку ServiceAccount и Role через ClusterRoleBinding
+```
 
 ## kubernetes-templating
 2023-08-19 Сделал задания из kubernetes-templating:
@@ -79,4 +81,12 @@ yd47 Platform repository
 Изучил:
   - создание CR и описание его в CRD;
   - создание k8s оператора
+```
+
+## kubernetes-monitoring
+2023-11 Сделал задания из kubernetes-monitoring:
+```
+Изучил:
+  - деплой prometheus стека в кубер;
+  - автообнаружение сервисов и pod'ов через оператор
 ```

--- a/kubernetes-monitoring/Dockerfile
+++ b/kubernetes-monitoring/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:1.25
+
+RUN mkdir /app/ && \
+    usermod -u 1001 nginx && groupmod -g 1001 nginx
+
+EXPOSE 8000
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-monitoring/nginx.conf
+++ b/kubernetes-monitoring/nginx.conf
@@ -1,0 +1,38 @@
+user  nginx;
+worker_processes  auto;
+
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+    error_log  /var/log/nginx/error.log notice;
+
+    keepalive_timeout  65;
+
+    server {
+        listen       8000;
+        server_name  _;
+
+#        location / {
+#            root   /app;
+#            index  index.html index.htm;
+#        }
+
+        location /basic_status {
+             stub_status on;
+             access_log off;
+             }
+
+    }
+}

--- a/kubernetes-monitoring/prometheus-service-monitor.yml
+++ b/kubernetes-monitoring/prometheus-service-monitor.yml
@@ -1,0 +1,192 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hw8-ns
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hw8-dp
+  namespace: hw8-ns
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: hw8-pod
+  template:
+    metadata:
+      name: hw8-pod
+      labels:
+        app: hw8-pod
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9113"
+    spec:
+      containers:
+      - image: hardkov/otus-hw8:v0.0.1
+        name: hw8-container
+        ports:
+        - containerPort: 8000
+      # описание nginx-exporter
+      - name: nginx-exporter
+        image: nginx/nginx-prometheus-exporter:0.10.0
+        args: ["-nginx.scrape-uri", "http://localhost:8000/basic_status"]
+        ports:
+          - containerPort: 9113
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hw8-svc
+  namespace: hw8-ns
+spec:
+  selector:
+    app: hw8-pod
+  type: ClusterIP
+  ports:
+    - name: hw8-svc-port
+      protocol: TCP
+      port: 80
+      targetPort: 9113
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-data
+  namespace: hw8-ns
+  labels:
+    type: host
+    app: prometheus-deployment
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  # не использовать такой тип хранилища в проде
+  # здесь используется в рамках обучения
+  hostPath:
+    path: "/data/promdata"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-data
+  namespace: hw8-ns
+  labels:
+    app: prometheus-deployment
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 500Mi
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: hw8-ns
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: hw8-ns
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hw8-svc-mon
+  namespace: hw8-ns
+  labels:
+    team: frontend
+spec:
+  selector:
+    matchLabels:
+      app: hw8-svc
+  endpoints:
+  - port: hw8-svc-port
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  namespace: hw8-ns
+spec:
+  serviceAccountName: prometheus
+  serviceMonitorSelector:
+    matchLabels:
+      team: frontend
+  resources:
+    requests:
+      memory: 400Mi
+  enableAdminAPI: false
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: hw8-ns
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    port: 9090
+    targetPort: web
+  selector:
+    prometheus: prometheus
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-ingress
+  namespace: hw8-ns
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus
+                port:
+                  number: 9090

--- a/kubernetes-monitoring/prometheus-service-monitor.yml
+++ b/kubernetes-monitoring/prometheus-service-monitor.yml
@@ -2,6 +2,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: hw8-ns
+  labels:
+    monitoring: "true"
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
 
 ---
 apiVersion: apps/v1
@@ -41,6 +49,8 @@ kind: Service
 metadata:
   name: hw8-svc
   namespace: hw8-ns
+  labels:
+    app: hw8-svc
 spec:
   selector:
     app: hw8-pod
@@ -56,7 +66,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: pv-data
-  namespace: hw8-ns
+  namespace: monitoring
   labels:
     type: host
     app: prometheus-deployment
@@ -75,7 +85,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: pvc-data
-  namespace: hw8-ns
+  namespace: monitoring
   labels:
     app: prometheus-deployment
 spec:
@@ -109,7 +119,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
-  namespace: hw8-ns
+  namespace: monitoring
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -123,7 +133,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: hw8-ns
+  namespace: monitoring
 
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -145,23 +155,26 @@ apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: prometheus
-  namespace: hw8-ns
+  namespace: monitoring
 spec:
   serviceAccountName: prometheus
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      monitoring: "true"
   serviceMonitorSelector:
     matchLabels:
       team: frontend
   resources:
     requests:
       memory: 400Mi
-  enableAdminAPI: false
+  enableAdminAPI: true
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
-  namespace: hw8-ns
+  namespace: monitoring
 spec:
   type: ClusterIP
   ports:
@@ -176,7 +189,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: prometheus-ingress
-  namespace: hw8-ns
+  namespace: monitoring
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:

--- a/kubernetes-monitoring/prometheus_without_operator/nginx-deployment.yml
+++ b/kubernetes-monitoring/prometheus_without_operator/nginx-deployment.yml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hw8-ns
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hw8-dp
+  namespace: hw8-ns
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: hw8-pod
+  template:
+    metadata:
+      name: hw8-pod
+      labels:
+        app: hw8-pod
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9113"
+    spec:
+      containers:
+      - image: hardkov/otus-hw8:v0.0.1
+        name: hw8-container
+        ports:
+        - containerPort: 8000
+      # описание nginx-exporter
+      - name: nginx-exporter
+        image: nginx/nginx-prometheus-exporter:0.10.0
+        args: ["-nginx.scrape-uri", "http://localhost:8000/basic_status"]
+        ports:
+          - containerPort: 9113
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hw8-svc
+  namespace: hw8-ns
+spec:
+  selector:
+    app: hw8-pod
+  type: ClusterIP
+  ports:
+    - name: hw8-svc-port
+      protocol: TCP
+      port: 80
+      targetPort: 9113
+
+#---
+#apiVersion: networking.k8s.io/v1
+#kind: Ingress
+#metadata:
+#  name: hw8-ingress
+#  namespace: hw8-ns
+#  annotations:
+#    kubernetes.io/ingress.class: "nginx"
+#spec:
+#  rules:
+#    - http:
+#        paths:
+#          - path: /basic_status
+#            pathType: Prefix
+#            backend:
+#              service:
+#                name: hw8-svc
+#                port:
+#                  number: 8000

--- a/kubernetes-monitoring/prometheus_without_operator/prometheus-deploy-stack.yml
+++ b/kubernetes-monitoring/prometheus_without_operator/prometheus-deploy-stack.yml
@@ -1,0 +1,202 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-data
+  namespace: monitoring
+  labels:
+    type: host
+    app: prometheus-deployment
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  # не использовать такой тип хранилища в проде
+  # здесь используется в рамках обучения
+  hostPath:
+    path: "/data/promdata"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-data
+  namespace: monitoring
+  labels:
+    app: prometheus-deployment
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 500Mi
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: monitoring
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval:     15s
+      evaluation_interval: 15s
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets:
+    rule_files:
+      # - "example-file.yml"
+    scrape_configs:
+    - job_name: "prometheus"
+      static_configs:
+        - targets: ["localhost:9090"]
+    - job_name: "hw8-app"
+      static_configs:
+        - targets: [""]
+# Автообнаружение, которое не заработало      
+#    - job_name: "k8pods"
+#      kubernetes_sd_configs:
+#      - role: pod
+#      relabel_configs:
+#      - source_labels: [__meta_kubernetes_pod_container_port_name]
+#        regex: hw8-dp
+#        action: keep
+#      - source_labels: [__meta_kubernetes_pod_container_name]
+#        target_label: job
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus
+        args:
+          - "--storage.tsdb.retention=6h"
+          - "--storage.tsdb.path=/prometheus"
+          - "--config.file=/etc/prometheus/prometheus.yml"
+        ports:
+        - name: web
+          containerPort: 9090
+        volumeMounts:
+        - name: prometheus-config-volume
+          mountPath: /etc/prometheus
+        - name: prometheus-storage-volume
+          mountPath: /prometheus
+      restartPolicy: Always
+      volumes:
+      - name: prometheus-config-volume
+        configMap:
+            defaultMode: 420
+            name: prometheus-config
+      - name: prometheus-storage-volume
+        persistentVolumeClaim:
+            claimName: pvc-data
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: prometheus-service
+    namespace: monitoring
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port:   "9090"
+spec:
+  selector:
+      app: prometheus
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - port: 8080
+    targetPort: 9090
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-ingress
+  namespace: monitoring
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus-service
+                port:
+                  number: 8080


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - контейнер с nginx с доступом к базовой информации о состоянии сервиса по /basic_status;
 - описан deployment с nginx + nginx-exporter добавлен как sidecar в тот же pod;
 - потренировался с деплоем стека без оператора, конфиг лежит в каталоге prometheus_without_operator, не получилось сделать автодискавери через лейблы, например:
 ```
__meta_kubernetes_service_name
__meta_kubernetes_namespace
__meta_kubernetes_service_name
```
 - поднял стек через оператора, сделал автообнаружение сервиса из другого namespace

## Как запустить проект:
 - `kubectl apply -f prometheus-service-monitor.yml`

## Как проверить работоспособность:
 - Открыть вебку prometheus по ip адресу, который получил ingress из namespace monitoring

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
