### PR TITLE
Сделал задания из kubernetes-storage

### DIFF
--- a/kubernetes-storage/hw/pod.yaml
+++ b/kubernetes-storage/hw/pod.yaml
@@ -1,0 +1,16 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: storage-pod
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: [ "sleep", "1000000" ]
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: storage-pvc

--- a/kubernetes-storage/hw/pvc.yaml
+++ b/kubernetes-storage/hw/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-hostpath-sc

--- a/kubernetes-storage/hw/storageclass.yaml
+++ b/kubernetes-storage/hw/storageclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true


### PR DESCRIPTION
# Выполнено ДЗ № 12

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Основное задание

#### Установка HostPath CSI драйвера

```
git clone https://github.com/kubernetes-csi/csi-driver-host-path
deploy/kubernetes-1.26/deploy.sh
```

#### Установка storageclass для динамического выделения диска:

```
kubectl apply -f ./hw/storageclass.yaml
kubectl get sc
NAME                           PROVISIONER                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE 
csi-hostpath-sc                hostpath.csi.k8s.io             Delete          Immediate              true                   57m 
```

#### Создание пода с динамическим диском класса "HostPath CSI":

```
kubectl apply -f ./hw/pvc.yml
kubectl apply -f ./hw/pod.yml
```

```
kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                 STORAGECLASS      REASON   AGE
pvc-0d01102f-ea8a-473f-b7d4-ead143e8f3d6   1Gi        RWO            Delete           Bound    default/storage-pvc   csi-hostpath-sc            2m14s

kubectl get pvc
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
storage-pvc   Bound    pvc-0d01102f-ea8a-473f-b7d4-ead143e8f3d6   1Gi        RWO            csi-hostpath-sc   2m45s

kubectl get volumeattachments
NAME                                                                   ATTACHER              PV                                         NODE                        ATTACHED   AGE
csi-26ceb6d3354506dd957a1d1a3743e8b41ffa985ca9d230b80cc71f8f1bb36156   hostpath.csi.k8s.io   pvc-0d01102f-ea8a-473f-b7d4-ead143e8f3d6   cl1h66s7p14gbdtbldu8-amig   true       4m2s
```

#### Проверка работы:

```
kubectl exec -it storage-pod -- sh

echo "something" > /data/test.file
```

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
